### PR TITLE
Minor enhancement of the default url in config file.

### DIFF
--- a/client/bush/config.yaml
+++ b/client/bush/config.yaml
@@ -1,2 +1,2 @@
 # The API endpoint, set this to the one you plan to use most.
-url: https://127.0.0.1/bush
+url: null


### PR DESCRIPTION
With this modification, the first run, only print:

```
('Connection aborted.', ConnectionRefusedError(111, 'Connection refused'))
```

Before, this message was also printed:

```
The API URL doesn't end with a '/', I'll go on and assume you know what
you are doing. But if something fails you might want to try to add one.
```

I think it give a better first impression to not show this warning.
