### PR TITLE
Add support for url aliases. Closes #34.

### DIFF
--- a/client/bush/cli.py
+++ b/client/bush/cli.py
@@ -160,6 +160,10 @@ def main():
     config = bush.config.load_config(args.config)
 
     url = args.url or config.get('url')
+    url_aliases = config.get('url_aliases')
+
+    if url_aliases and url in url_aliases:
+        url = url_aliases[url]
 
     if url is None:
         exit("No URL specified, check your configuration or specify --url.")

--- a/client/bush/config.yaml
+++ b/client/bush/config.yaml
@@ -1,2 +1,6 @@
 # The API endpoint, set this to the one you plan to use most.
 url: null
+
+# url_aliases:
+#   work: https://host1/path/
+#   ctf: http://host2/path/


### PR DESCRIPTION
You can now use alias instead of url.
This will work:
`bush -u work ls`
If you add this in the config file:

```
url_aliases:
  work: https://host1/path/
```
