### PR TITLE
Add HTTP Basic-Auth on client-side.

### DIFF
--- a/client/bush/api.py
+++ b/client/bush/api.py
@@ -62,7 +62,11 @@ class BushAPI():
                 'User-Agent': 'bush.py.%s' % bush.meta.__version__,
                 })
 
-        if username or password:
+        scheme = urllib.parse.urlparse(self.base)[0]
+        if (username or password) and scheme != 'https':
+            if not self.confirmation("Sending credentials over %r is insecure."
+                                     % scheme, level=EXTREME):
+                raise KeyboardInterrupt()
             self.requests.auth = (username, password)
 
     def confirmation(self, msg, level):

--- a/client/bush/api.py
+++ b/client/bush/api.py
@@ -11,6 +11,7 @@ import requests
 
 from requests_toolbelt import MultipartEncoder, MultipartEncoderMonitor
 
+import bush.meta
 
 INFO = 0
 LOW = 1
@@ -52,9 +53,17 @@ class BushFile():
 
 class BushAPI():
 
-    def __init__(self, base, token=None):
+    def __init__(self, base, username=None, password=None):
         self.base = base
-        self.token = token
+
+        self.requests = requests.session()
+
+        self.requests.headers.update({
+                'User-Agent': 'bush.py.%s' % bush.meta.__version__,
+                })
+
+        if username or password:
+            self.requests.auth = (username, password)
 
     def confirmation(self, msg, level):
         # Don't confirm anything by default!
@@ -111,7 +120,7 @@ class BushAPI():
         return True
 
     def list(self):
-        r = requests.get(self.url("index.php?request=list"))
+        r = self.requests.get(self.url("index.php?request=list"))
         self.assert_response(r)
         return [BushFile(url=self.getddl(f['tag']), **f)
                 for f in json.loads(r.text)]
@@ -160,7 +169,7 @@ class BushAPI():
 
         monitor = MultipartEncoderMonitor(encoder, _callback)
 
-        r = requests.post(self.url('index.php?request=upload'), data=monitor,
+        r = self.requests.post(self.url('index.php?request=upload'), data=monitor,
                           headers={'Content-Type': monitor.content_type})
 
         if _callback:
@@ -178,7 +187,7 @@ class BushAPI():
 
     def download(self, tag, dest, callback=None, chunksz=8192):
 
-        r = requests.get(self.url("index.php?request=get"),
+        r = self.requests.get(self.url("index.php?request=get"),
                          params={"tag": tag}, stream=True)
 
         self.assert_response(r)
@@ -288,7 +297,7 @@ class BushAPI():
 
     def delete(self, tag):
 
-        r = requests.get(self.url("index.php?request=delete"),
+        r = self.requests.get(self.url("index.php?request=delete"),
                          params={"tag": tag})
 
         self.assert_response(r)
@@ -297,7 +306,7 @@ class BushAPI():
 
     def reset(self):
 
-        r = requests.get(self.url("index.php?request=reset"))
+        r = self.requests.get(self.url("index.php?request=reset"))
 
         self.assert_response(r)
 

--- a/client/bush/cli.py
+++ b/client/bush/cli.py
@@ -183,11 +183,10 @@ you are doing. But if something fails you might want to try to add one.""",
     username = args.username or server.get('username')
     password = args.password or server.get('password')
 
-    api = UIAPI(url, username=username, password=password)
-
     try:
+        api = UIAPI(url, username=username, password=password)
         args.callback(api, args)
     except KeyboardInterrupt:
-        print()  # Canceled by user :(
+        print('interrupted')  # Canceled by user :(
     except Exception if not args.debug else () as e:
         exit(e)

--- a/client/bush/cli.py
+++ b/client/bush/cli.py
@@ -150,6 +150,8 @@ def main():
     sub.set_defaults(callback=do_reset)
 
     parser.add_argument('-u', '--url', help="API endpoint")
+    parser.add_argument('-U', '--username', help="API username")
+    parser.add_argument('-P', '--password', help="API password")
     parser.add_argument("-c", "--config", type=argparse.FileType("r"),
                         help="path overwriting the default configuration file")
     parser.add_argument('-d', '--debug', action='store_true',
@@ -159,11 +161,15 @@ def main():
 
     config = bush.config.load_config(args.config)
 
-    url = args.url or config.get('url')
-    url_aliases = config.get('url_aliases')
+    servers = config.get('servers') or [{}]
 
-    if url_aliases and url in url_aliases:
-        url = url_aliases[url]
+    for server in servers:
+        if args.url in (server.get('url'), server.get('alias')):
+            break
+    else:
+        server = servers[0] if args.url is None else {}
+
+    url = server.get('url', args.url)
 
     if url is None:
         exit("No URL specified, check your configuration or specify --url.")
@@ -174,7 +180,10 @@ The API URL doesn't end with a '/', I'll go on and assume you know what
 you are doing. But if something fails you might want to try to add one.""",
               file=sys.stderr)
 
-    api = UIAPI(url)
+    username = args.username or server.get('username')
+    password = args.password or server.get('password')
+
+    api = UIAPI(url, username=username, password=password)
 
     try:
         args.callback(api, args)

--- a/client/bush/config.yaml
+++ b/client/bush/config.yaml
@@ -1,6 +1,8 @@
-# The API endpoint, set this to the one you plan to use most.
-url: null
+# The first server in the list will be used by default.
 
-# url_aliases:
-#   work: https://host1/path/
-#   ctf: http://host2/path/
+servers:
+
+  - url: null
+    username: null
+    password: null
+    alias: sample

--- a/tests/config/config.yaml
+++ b/tests/config/config.yaml
@@ -1,2 +1,4 @@
-# The API endpoint, set this to the one you plan to use most.
-url: http://127.0.0.1:8080/
+servers:
+
+  - url: https://127.0.0.1/
+    alias: bestpig

--- a/tests/config/config.yaml
+++ b/tests/config/config.yaml
@@ -1,4 +1,4 @@
 servers:
 
-  - url: https://127.0.0.1/
+  - url: http://127.0.0.1:8080/
     alias: bestpig


### PR DESCRIPTION
This also implements per-server configuration with in particular the credentials. Alias is now a server property.

This is retro-compatible with the old system.
